### PR TITLE
Add Linux arm64 and musl/Alpine prebuild support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,8 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |-
               set -e &&
+              rustup update stable &&
+              rustup default stable &&
               yarn build --target x86_64-unknown-linux-gnu &&
               strip *.node
           - host: ubuntu-latest
@@ -57,9 +59,9 @@ jobs:
     name: stable - ${{ matrix.settings.target }} - node@18
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         if: ${{ !matrix.settings.docker }}
         with:
           node-version: 18
@@ -72,7 +74,7 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
       - name: Cache cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -96,7 +98,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Setup node x86
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         if: matrix.settings.target == 'i686-pc-windows-msvc'
         with:
           node-version: 18
@@ -138,9 +140,9 @@ jobs:
           - '18'
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
@@ -170,9 +172,9 @@ jobs:
           - '18'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
@@ -202,9 +204,9 @@ jobs:
           - '18'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
@@ -234,9 +236,9 @@ jobs:
           - '18'
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
@@ -266,9 +268,9 @@ jobs:
           - '18'
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
@@ -291,9 +293,9 @@ jobs:
       - build
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 18
           check-latest: true
@@ -329,9 +331,9 @@ jobs:
       - test-linux-arm64-musl-binding
       - universal-macOS
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 18
           check-latest: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,8 +41,14 @@ jobs:
               yarn build --target x86_64-unknown-linux-gnu &&
               strip *.node
           - host: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            build: yarn build --target x86_64-unknown-linux-musl --zig
+          - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             build: yarn build --target aarch64-unknown-linux-gnu --use-napi-cross
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            build: yarn build --target aarch64-unknown-linux-musl --zig
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |
@@ -76,7 +82,7 @@ jobs:
             target/
           key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
       - uses: goto-bus-stop/setup-zig@v2
-        if: ${{ matrix.settings.target == 'armv7-unknown-linux-gnueabihf' }}
+        if: ${{ contains(matrix.settings.target, 'musl') || matrix.settings.target == 'armv7-unknown-linux-gnueabihf' }}
         with:
           version: 0.10.1
       - name: Setup toolchain
@@ -183,6 +189,38 @@ jobs:
         shell: bash
       - name: Test bindings
         run: docker run --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim yarn test
+  test-linux-x64-musl-binding:
+    name: Test bindings on Linux-x64-musl - node@${{ matrix.node }}
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - '14'
+          - '16'
+          - '18'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          check-latest: true
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: bindings-x86_64-unknown-linux-musl
+          path: .
+      - name: List packages
+        run: ls -R .
+        shell: bash
+      - name: Test bindings
+        run: docker run --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-alpine yarn test
   test-linux-arm64-gnu-binding:
     name: Test bindings on Linux-arm64-gnu - node@${{ matrix.node }}
     needs:
@@ -215,6 +253,38 @@ jobs:
         shell: bash
       - name: Test bindings
         run: yarn test
+  test-linux-arm64-musl-binding:
+    name: Test bindings on Linux-arm64-musl - node@${{ matrix.node }}
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - '14'
+          - '16'
+          - '18'
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          check-latest: true
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: bindings-aarch64-unknown-linux-musl
+          path: .
+      - name: List packages
+        run: ls -R .
+        shell: bash
+      - name: Test bindings
+        run: docker run --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-alpine yarn test
   universal-macOS:
     name: Build universal macOS binary
     needs:
@@ -254,7 +324,9 @@ jobs:
     needs:
       - test-macOS-windows-binding
       - test-linux-x64-gnu-binding
+      - test-linux-x64-musl-binding
       - test-linux-arm64-gnu-binding
+      - test-linux-arm64-musl-binding
       - universal-macOS
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,7 @@ jobs:
             build: yarn build --target x86_64-unknown-linux-musl --zig
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            build: yarn build --target aarch64-unknown-linux-gnu --use-napi-cross
+            build: yarn build --target aarch64-unknown-linux-gnu --zig
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
             build: yarn build --target aarch64-unknown-linux-musl --zig
@@ -82,7 +82,7 @@ jobs:
             target/
           key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
       - uses: goto-bus-stop/setup-zig@v2
-        if: ${{ contains(matrix.settings.target, 'musl') || matrix.settings.target == 'armv7-unknown-linux-gnueabihf' }}
+        if: ${{ contains(matrix.settings.target, 'musl') || matrix.settings.target == 'aarch64-unknown-linux-gnu' || matrix.settings.target == 'armv7-unknown-linux-gnueabihf' }}
         with:
           version: 0.10.1
       - name: Setup toolchain
@@ -115,7 +115,7 @@ jobs:
         if: ${{ !matrix.settings.docker }}
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-${{ matrix.settings.target }}
           path: ${{ env.APP_NAME }}.*.node
@@ -148,7 +148,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
         with:
           name: bindings-${{ matrix.settings.target }}
           path: .
@@ -180,7 +180,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
         with:
           name: bindings-x86_64-unknown-linux-gnu
           path: .
@@ -212,7 +212,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
         with:
           name: bindings-x86_64-unknown-linux-musl
           path: .
@@ -244,7 +244,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
         with:
           name: bindings-aarch64-unknown-linux-gnu
           path: .
@@ -276,7 +276,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
         with:
           name: bindings-aarch64-unknown-linux-musl
           path: .
@@ -301,19 +301,19 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Download macOS x64 artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
         with:
           name: bindings-x86_64-apple-darwin
           path: artifacts
       - name: Download macOS arm64 artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
         with:
           name: bindings-aarch64-apple-darwin
           path: artifacts
       - name: Combine binaries
         run: yarn universal
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: bindings-universal-apple-darwin
           path: ${{ env.APP_NAME }}.*.node
@@ -339,7 +339,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
       - name: Move artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,10 +25,10 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
+          - host: macos-15-intel
             target: x86_64-apple-darwin
             build: |
-              yarn build
+              yarn build --target x86_64-apple-darwin
               strip -x *.node
           - host: windows-latest
             build: yarn build
@@ -51,7 +51,7 @@ jobs:
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
             build: yarn build --target aarch64-unknown-linux-musl --zig
-          - host: macos-latest
+          - host: macos-15
             target: aarch64-apple-darwin
             build: |
               yarn build --target aarch64-apple-darwin
@@ -130,7 +130,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
+          - host: macos-15-intel
             target: x86_64-apple-darwin
           - host: windows-latest
             target: x86_64-pc-windows-msvc
@@ -291,7 +291,7 @@ jobs:
     name: Build universal macOS binary
     needs:
       - build
-    runs-on: macos-latest
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v6
       - name: Setup node

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,9 @@ jobs:
               set -e &&
               yarn build --target x86_64-unknown-linux-gnu &&
               strip *.node
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            build: yarn build --target aarch64-unknown-linux-gnu --use-napi-cross
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |
@@ -180,6 +183,38 @@ jobs:
         shell: bash
       - name: Test bindings
         run: docker run --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim yarn test
+  test-linux-arm64-gnu-binding:
+    name: Test bindings on Linux-arm64-gnu - node@${{ matrix.node }}
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - '14'
+          - '16'
+          - '18'
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          check-latest: true
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: bindings-aarch64-unknown-linux-gnu
+          path: .
+      - name: List packages
+        run: ls -R .
+        shell: bash
+      - name: Test bindings
+        run: yarn test
   universal-macOS:
     name: Build universal macOS binary
     needs:
@@ -219,6 +254,7 @@ jobs:
     needs:
       - test-macOS-windows-binding
       - test-linux-x64-gnu-binding
+      - test-linux-arm64-gnu-binding
       - universal-macOS
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The official Node bindings are in a jinx with limited support for Node versions 
 
 ## Supports:
 > * Windows x86_64
-> * Linux x86_64
-> * Linux aarch64 (glibc)
+> * Linux x86_64 (glibc, musl/Alpine)
+> * Linux aarch64 (glibc, musl/Alpine)
 > * MacOS aarch64/x86_64
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The official Node bindings are in a jinx with limited support for Node versions 
 ## Supports:
 > * Windows x86_64
 > * Linux x86_64
+> * Linux aarch64 (glibc)
 > * MacOS aarch64/x86_64
 
 ## Installation

--- a/npm/linux-arm64-gnu/README.md
+++ b/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@anush008/tokenizers-linux-arm64-gnu`
+
+This is the **aarch64-unknown-linux-gnu** binary for `@anush008/tokenizers`

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@anush008/tokenizers-linux-arm64-gnu",
+  "version": "0.0.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "tokenizers.linux-arm64-gnu.node",
+  "files": [
+    "tokenizers.linux-arm64-gnu.node"
+  ],
+  "description": "Multi-arch builds of HuggingFace tokenizers",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  },
+  "repository": "https://github.com/Anush008/tokenizers",
+  "libc": [
+    "glibc"
+  ]
+}

--- a/npm/linux-arm64-musl/README.md
+++ b/npm/linux-arm64-musl/README.md
@@ -1,0 +1,3 @@
+# `@anush008/tokenizers-linux-arm64-musl`
+
+This is the **aarch64-unknown-linux-musl** binary for `@anush008/tokenizers`

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@anush008/tokenizers-linux-arm64-musl",
+  "version": "0.0.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "tokenizers.linux-arm64-musl.node",
+  "files": [
+    "tokenizers.linux-arm64-musl.node"
+  ],
+  "description": "Multi-arch builds of HuggingFace tokenizers",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  },
+  "repository": "https://github.com/Anush008/tokenizers",
+  "libc": [
+    "musl"
+  ]
+}

--- a/npm/linux-x64-musl/README.md
+++ b/npm/linux-x64-musl/README.md
@@ -1,0 +1,3 @@
+# `@anush008/tokenizers-linux-x64-musl`
+
+This is the **x86_64-unknown-linux-musl** binary for `@anush008/tokenizers`

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@anush008/tokenizers-linux-x64-musl",
+  "version": "0.0.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "tokenizers.linux-x64-musl.node",
+  "files": [
+    "tokenizers.linux-x64-musl.node"
+  ],
+  "description": "Multi-arch builds of HuggingFace tokenizers",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  },
+  "repository": "https://github.com/Anush008/tokenizers",
+  "libc": [
+    "musl"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
       "additional": [
         "x86_64-pc-windows-msvc",
         "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl",
         "aarch64-unknown-linux-gnu",
+        "aarch64-unknown-linux-musl",
         "universal-apple-darwin"
       ]
     }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "additional": [
         "x86_64-pc-windows-msvc",
         "x86_64-unknown-linux-gnu",
+        "aarch64-unknown-linux-gnu",
         "universal-apple-darwin"
       ]
     }


### PR DESCRIPTION
## Summary

This PR adds the missing Linux prebuilds that the loader already expects:

- publish `aarch64-unknown-linux-gnu`
- publish `x86_64-unknown-linux-musl`
- publish `aarch64-unknown-linux-musl`
- add the missing npm package metadata for those binaries
- build and test the new targets in GitHub Actions
- document Linux glibc + musl/Alpine support in the README

`index.js` already contains the `linux/arm64` and `linux/*-musl` loading paths, but the corresponding published packages are missing today. In practice, that means arm64 Linux and Alpine users still cannot install and use the package cleanly.

## Why I'm requesting this

This support is fairly urgent on our side. We are trying to use this package on Linux arm64 machines, and Alpine compatibility is also important for some of our deployment targets.

If you are open to it, I would really appreciate merging and publishing this when you can. It would help a lot, and it should unblock both arm64 Linux users and Alpine users who are currently stuck on the missing prebuilds.

## Validation

- `corepack yarn install`
- `corepack yarn napi prepublish -t npm --dry-run`
- JSON parse check for the updated package manifests

I could not do a full local native build in this environment because Rust/Cargo is not installed here, so the added CI jobs are intended to cover the new build/test paths.
