### PR TITLE
Bump tokenizers crate from 0.14.0 to 0.22.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ crate-type = ["cdylib"]
 napi = { version = "2.12.2", default-features = false, features = ["napi4"] }
 napi-derive = "2.12.2"
 serde = { version = "1.0.188", features = ["derive"] }
-tokenizers = "0.14.0"
+tokenizers = "0.22.2"
+ahash = { version = "0.8", features = ["serde"] }
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/npm/darwin-universal/package.json
+++ b/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anush008/tokenizers-darwin-universal",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "os": [
     "darwin"
   ],

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anush008/tokenizers-linux-arm64-gnu",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "os": [
     "linux"
   ],

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anush008/tokenizers-linux-arm64-musl",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anush008/tokenizers-linux-x64-gnu",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anush008/tokenizers-linux-x64-musl",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "os": [
     "linux"
   ],

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anush008/tokenizers-win32-x64-msvc",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "os": [
     "win32"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anush008/tokenizers",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "index.js",
   "types": "index.d.ts",
   "publishConfig": {

--- a/src/decoders.rs
+++ b/src/decoders.rs
@@ -29,7 +29,7 @@ impl Decoder {
       .read()
       .unwrap()
       .decode(tokens)
-      .map_err(|e| Error::from_reason(format!("{}", e)))
+      .map_err(|e| Error::from_reason(format!("{e}")))
   }
 }
 
@@ -90,9 +90,11 @@ pub fn fuse_decoder() -> Decoder {
 #[napi]
 pub fn metaspace_decoder(
   #[napi(ts_arg_type = "string = '▁'")] replacement: Option<String>,
-  #[napi(ts_arg_type = "bool = true")] add_prefix_space: Option<bool>,
+  #[napi(ts_arg_type = "prepend_scheme = 'always'")] prepend_scheme: Option<String>,
+  #[napi(ts_arg_type = "split = true")] split: Option<bool>,
 ) -> Result<Decoder> {
-  let add_prefix_space = add_prefix_space.unwrap_or(true);
+  use tk::pre_tokenizers::metaspace::PrependScheme;
+  let split = split.unwrap_or(true);
   let replacement = replacement.unwrap_or("▁".to_string());
   if replacement.chars().count() != 1 {
     return Err(Error::from_reason(
@@ -100,9 +102,20 @@ pub fn metaspace_decoder(
     ));
   }
   let replacement = replacement.chars().next().unwrap();
+  let prepend_scheme: PrependScheme =
+    match prepend_scheme.unwrap_or(String::from("always")).as_str() {
+      "always" => PrependScheme::Always,
+      "first" => PrependScheme::First,
+      "never" => PrependScheme::Never,
+      _ => {
+        return Err(Error::from_reason(
+          "prepend_scheme is supposed to be either 'always', 'first' or 'never'",
+        ));
+      }
+    };
   Ok(Decoder {
     decoder: Some(Arc::new(RwLock::new(
-      tk::decoders::metaspace::Metaspace::new(replacement, add_prefix_space).into(),
+      tk::decoders::metaspace::Metaspace::new(replacement, prepend_scheme, split).into(),
     ))),
   })
 }

--- a/src/normalizers.rs
+++ b/src/normalizers.rs
@@ -25,7 +25,7 @@ impl Normalizer {
 
     self
       .normalize(&mut normalized)
-      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+      .map_err(|e| Error::from_reason(format!("{e}")))?;
 
     Ok(normalized.get().to_string())
   }

--- a/src/pre_tokenizers.rs
+++ b/src/pre_tokenizers.rs
@@ -80,7 +80,7 @@ impl PreTokenizer {
 
     self
       .pre_tokenize(&mut pretokenized)
-      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+      .map_err(|e| Error::from_reason(format!("{e}")))?;
 
     pretokenized
       .get_splits(tk::OffsetReferential::Original, tk::OffsetType::Char)
@@ -155,9 +155,11 @@ pub fn bert_pre_tokenizer() -> PreTokenizer {
 #[napi]
 pub fn metaspace_pre_tokenizer(
   #[napi(ts_arg_type = "string = '▁'")] replacement: Option<String>,
-  #[napi(ts_arg_type = "bool = true")] add_prefix_space: Option<bool>,
+  #[napi(ts_arg_type = "prepend_scheme = 'always'")] prepend_scheme: Option<String>,
+  #[napi(ts_arg_type = "split = true")] split: Option<bool>,
 ) -> Result<PreTokenizer> {
-  let add_prefix_space = add_prefix_space.unwrap_or(true);
+  use tk::pre_tokenizers::metaspace::PrependScheme;
+  let split = split.unwrap_or(true);
   let replacement = replacement.unwrap_or("▁".to_string());
   if replacement.chars().count() != 1 {
     return Err(Error::from_reason(
@@ -165,10 +167,21 @@ pub fn metaspace_pre_tokenizer(
     ));
   }
   let replacement = replacement.chars().next().unwrap();
+  let prepend_scheme: PrependScheme =
+    match prepend_scheme.unwrap_or(String::from("always")).as_str() {
+      "always" => PrependScheme::Always,
+      "first" => PrependScheme::First,
+      "never" => PrependScheme::Never,
+      _ => {
+        return Err(Error::from_reason(
+          "prepend_scheme is supposed to be either 'always', 'first' or 'never'",
+        ));
+      }
+    };
 
   Ok(PreTokenizer {
     pretok: Some(Arc::new(RwLock::new(
-      tk::pre_tokenizers::metaspace::Metaspace::new(replacement, add_prefix_space).into(),
+      tk::pre_tokenizers::metaspace::Metaspace::new(replacement, prepend_scheme, split).into(),
     ))),
   })
 }

--- a/src/tasks/models.rs
+++ b/src/tasks/models.rs
@@ -21,7 +21,7 @@ impl Task for BPEFromFilesTask {
       .take()
       .ok_or(Error::from_reason("Empty builder".to_string()))?
       .build()
-      .map_err(|e| Error::from_reason(format!("{}", e)))
+      .map_err(|e| Error::from_reason(format!("{e}")))
   }
 
   fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -45,7 +45,7 @@ impl Task for WordPieceFromFilesTask {
       .take()
       .ok_or(Error::from_reason("Empty builder".to_string()))?
       .build()
-      .map_err(|e| Error::from_reason(format!("{}", e)))
+      .map_err(|e| Error::from_reason(format!("{e}")))
   }
 
   fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -68,7 +68,7 @@ impl Task for WordLevelFromFilesTask {
       .take()
       .ok_or(Error::from_reason("Empty builder".to_string()))?
       .build()
-      .map_err(|e| Error::from_reason(format!("{}", e)))
+      .map_err(|e| Error::from_reason(format!("{e}")))
   }
 
   fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {

--- a/src/tasks/tokenizer.rs
+++ b/src/tasks/tokenizer.rs
@@ -28,7 +28,7 @@ impl Task for EncodeTask<'static> {
           .ok_or(Error::from_reason("No provided input"))?,
         self.add_special_tokens,
       )
-      .map_err(|e| Error::from_reason(format!("{}", e)))
+      .map_err(|e| Error::from_reason(format!("{e}")))
   }
 
   fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -55,7 +55,7 @@ impl Task for DecodeTask {
       .read()
       .unwrap()
       .decode(&self.ids, self.skip_special_tokens)
-      .map_err(|e| Error::from_reason(format!("{}", e)))
+      .map_err(|e| Error::from_reason(format!("{e}")))
   }
 
   fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -85,7 +85,7 @@ impl Task for EncodeBatchTask<'static> {
           .ok_or(Error::from_reason("No provided input"))?,
         self.add_special_tokens,
       )
-      .map_err(|e| Error::from_reason(format!("{}", e)))
+      .map_err(|e| Error::from_reason(format!("{e}")))
   }
 
   fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -118,7 +118,7 @@ impl Task for DecodeBatchTask {
       .read()
       .unwrap()
       .decode_batch(&ids, self.skip_special_tokens)
-      .map_err(|e| Error::from_reason(format!("{}", e)))
+      .map_err(|e| Error::from_reason(format!("{e}")))
   }
 
   fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -208,7 +208,7 @@ impl Tokenizer {
       .tokenizer
       .write()
       .unwrap()
-      .with_pre_tokenizer((*pre_tokenizer).clone());
+      .with_pre_tokenizer(Some((*pre_tokenizer).clone()));
   }
 
   #[napi]
@@ -217,7 +217,7 @@ impl Tokenizer {
       .tokenizer
       .write()
       .unwrap()
-      .with_decoder((*decoder).clone());
+      .with_decoder(Some((*decoder).clone()));
   }
 
   #[napi]
@@ -231,7 +231,7 @@ impl Tokenizer {
       .tokenizer
       .write()
       .unwrap()
-      .with_post_processor((*post_processor).clone());
+      .with_post_processor(Some((*post_processor).clone()));
   }
 
   #[napi]
@@ -240,7 +240,7 @@ impl Tokenizer {
       .tokenizer
       .write()
       .unwrap()
-      .with_normalizer((*normalizer).clone());
+      .with_normalizer(Some((*normalizer).clone()));
   }
 
   #[napi]
@@ -251,7 +251,7 @@ impl Tokenizer {
       .read()
       .unwrap()
       .save(path, pretty)
-      .map_err(|e| Error::from_reason(format!("{}", e)))
+      .map_err(|e| Error::from_reason(format!("{e}")))
   }
 
   #[napi]
@@ -341,9 +341,7 @@ impl Tokenizer {
       PreTokenizer,
       Processor,
       Decoder,
-    > = s
-      .parse()
-      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+    > = s.parse().map_err(|e| Error::from_reason(format!("{e}")))?;
     Ok(Self {
       tokenizer: Arc::new(RwLock::new(tokenizer)),
     })
@@ -352,7 +350,7 @@ impl Tokenizer {
   #[napi(factory)]
   pub fn from_file(file: String) -> Result<Self> {
     let tokenizer = tk::tokenizer::TokenizerImpl::from_file(file)
-      .map_err(|e| Error::from_reason(format!("Error loading from file{}", e)))?;
+      .map_err(|e| Error::from_reason(format!("Error loading from file{e}")))?;
     Ok(Self {
       tokenizer: Arc::new(RwLock::new(tokenizer)),
     })
@@ -472,7 +470,7 @@ impl Tokenizer {
       .write()
       .unwrap()
       .train_from_files(&mut trainer, files)
-      .map_err(|e| Error::from_reason(format!("{}", e)))?;
+      .map_err(|e| Error::from_reason(format!("{e}")))?;
     Ok(())
   }
 
@@ -504,7 +502,7 @@ impl Tokenizer {
           },
           add_special_tokens,
         )
-        .map_err(|e| Error::from_reason(format!("{}", e)))?
+        .map_err(|e| Error::from_reason(format!("{e}")))?
         .into(),
     )
   }


### PR DESCRIPTION
Updates the Rust `tokenizers` crate dependency from 0.14.0 (September 2023) to 0.22.2 (December 2025), picking up over two years of upstream improvements from huggingface/tokenizers.

## Changes

**Cargo.toml:**
- `tokenizers` 0.14.0 -> 0.22.2
- Added `ahash = { version = "0.8", features = ["serde"] }` (required by newer tokenizers crate for vocab hash maps)

**Source changes (required by API changes in tokenizers 0.15+):**
- `with_pre_tokenizer`, `with_decoder`, `with_post_processor`, `with_normalizer` now take `Option<T>` instead of `T`
- BPE `Vocab` type changed from re-export to `HashMap<String, u32>`, requires `AHashMap` conversion
- Metaspace decoder/pre-tokenizer: `add_prefix_space: bool` replaced by `prepend_scheme: String` + `split: bool` parameters
- `format!("{}", e)` replaced with `format!("{e}")` (Rust 2021 edition style)

## Verification

- Built and tested on `aarch64-unknown-linux-gnu` with Rust 1.94.0
- API surface (encode, getOffsets, getTokens, getIds, decode) verified working with nomic-embed-text-v1.5 tokenizer

## Context

The source changes follow the approach proven by [@inference-net/tokenizers](https://github.com/context-labs/tokenizers) (which bumped to 0.21.4) combined with the platform targets from v0.5.0. This PR goes further to 0.22.2.